### PR TITLE
Added http server available on boot/server

### DIFF
--- a/lib/boot/server.js
+++ b/lib/boot/server.js
@@ -47,7 +47,7 @@ exports = module.exports = function(logger, settings) {
 
     } else {
 
-      this.server.listen(settings.server.port, settings.server.host, function() {
+      this.httpServer = this.server.listen(settings.server.port, settings.server.host, function() {
         var addr = this.address()
         logger.info('app listening on %s:%d', addr.address, addr.port)
         done()


### PR DESCRIPTION
This change adds the result of sever.listen available on boot/server so one can close the httpServer or change it after it's creation.